### PR TITLE
[Reaction Prediction] Fix for rexgen_direct

### DIFF
--- a/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
+++ b/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
@@ -21,11 +21,12 @@ def main(args):
     torch.cuda.set_device(args['device'])
 
     if args['test_path'] is None:
-        test_set = USPTOCenter('test', num_processes=args['num_processes'])
+        test_set = USPTOCenter('test', num_processes=args['num_processes'], load=args['load'])
     else:
         test_set = WLNCenterDataset(raw_file_path=args['test_path'],
                                     mol_graph_path='test.bin',
-                                    num_processes=args['num_processes'])
+                                    num_processes=args['num_processes'],
+                                    load=args['load'])
     test_loader = DataLoader(test_set, batch_size=args['batch_size'],
                              collate_fn=collate_center, shuffle=False)
 
@@ -69,6 +70,9 @@ if __name__ == '__main__':
                              'task easier.')
     parser.add_argument('-np', '--num-processes', type=int, default=32,
                         help='Number of processes to use for data pre-processing')
+    parser.add_argument('--load', action='store_true', default=False,
+                        help='Whether to load constructed DGLGraphs. This is desired when the '
+                             'evaluation is performed multiple times and the dataset is large.')
     args = parser.parse_args().__dict__
     args.update(reaction_center_config)
 

--- a/python/dgllife/data/uspto.py
+++ b/python/dgllife/data/uspto.py
@@ -383,9 +383,8 @@ class WLNCenterDataset(object):
         self.complete_graphs = dict()
 
         path_to_reaction_file = raw_file_path + '.proc'
-        if not os.path.isfile(path_to_reaction_file):
-            print('Pre-processing graph edits from reaction data')
-            process_file(raw_file_path, num_processes)
+        print('Pre-processing graph edits from reaction data')
+        process_file(raw_file_path, num_processes)
 
         import time
         t0 = time.time()
@@ -1293,9 +1292,8 @@ class WLNRankDataset(object):
         self.size_cutoff = size_cutoff
 
         path_to_reaction_file = raw_file_path + '.proc'
-        if not os.path.isfile(path_to_reaction_file):
-            print('Pre-processing graph edits from reaction data')
-            process_file(raw_file_path, num_processes)
+        print('Pre-processing graph edits from reaction data')
+        process_file(raw_file_path, num_processes)
 
         self.reactant_mols, self.product_mols, self.real_bond_changes, \
         self.ids_for_small_samples = self.load_reaction_data(path_to_reaction_file, num_processes)


### PR DESCRIPTION
1. Previously we always try loading constructed DGLGraphs in `find_reaction_center_eval.py`. This may not be desired if users have multiple different files for evaluation with a same name. We now change the behavior to constructing DGLGraphs from scratch and users may choose to load existing DGLGraphs if they want.
2. Always pre-process graph edits from scratch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
