### PR TITLE
[Reaction Prediction] Handle Invalid Input Reactions

### DIFF
--- a/examples/reaction_prediction/rexgen_direct/README.md
+++ b/examples/reaction_prediction/rexgen_direct/README.md
@@ -31,7 +31,8 @@ Reaction centers refer to the pairs of atoms that lose/form a bond in the reacti
 (Weisfeiler-Lehman Network in this case) is trained to update the representations of all atoms. Then we combine 
 pairs of atom representations to predict the likelihood for the corresponding atoms to lose a bond or form a particular bond.
 
-In particular, we represent each candidate bond change as a 3-tuple a-b-c, where a and b are atom mapping numbers of two atoms in the reactants and c is the possible change, which can be losing a bond, forming a single bond, forming a double bond, forming a triple bond, and forming an aromatic bond.
+In particular, we represent each candidate bond change as a 3-tuple a-b-c, where a and b are atom mapping numbers of two atoms in the 
+reactants and c is the possible change, which can be losing a bond, forming a single bond, forming a double bond, forming a triple bond, and forming an aromatic bond.
 
 For evaluation, we select candidate bond changes with top-k scores for each reaction and compute the proportion of reactions 
 whose bond changes have all been included.
@@ -165,6 +166,16 @@ python find_reaction_center_eval.py --eval-path Z
 
 where `Z` is the path to the new test set as described above.
 
+Before training/evaluating the model, the script will first check if the model can properly handle 
+the reactions, resulting in the following 6 files:
+
+- train_valid_reactions.proc: Reactions in the training file that can be handled by the model
+- train_invalid_reactions.proc: Reactions in the training file that cannot be handled by the model
+- val_valid_reactions.proc: Reactions in the validation file that can be handled by the model
+- val_invalid_reactions.proc: Reactions in the validation file that cannot be handled by the model
+- test_valid_reactions.proc: Reactions in the test file that can be handled by the model
+- test_invalid_reactions.proc: Reactions in the test file that cannot be handled by the model
+
 ## Candidate Ranking
 
 ### Additional Dependency
@@ -261,18 +272,14 @@ python candidate_ranking_eval.py
 You can train a model on new datasets with
 
 ```bash
-python candidate_ranking_train.py --train-path X --val-path Y
+python candidate_ranking_train.py --train-path train_valid_reactions.proc --val-path val_valid_reactions.proc
 ```
-
-where `X`, `Y` are paths to the new training/validation set as described in the `Reaction Center Prediction` section.
 
 For evaluation,
 
 ```bash
-python candidate_ranking_train.py --eval-path Z
+python candidate_ranking_train.py --eval-path test_valid_reactions.proc
 ```
-
-where `Z` is the path to the new test set as described in the `Reaction Center Prediction` section.
 
 ### Common Issues
 

--- a/examples/reaction_prediction/rexgen_direct/candidate_ranking_eval.py
+++ b/examples/reaction_prediction/rexgen_direct/candidate_ranking_eval.py
@@ -20,7 +20,7 @@ def main(args, path_to_candidate_bonds):
             num_processes=args['num_processes'])
     else:
         test_set = WLNRankDataset(
-            raw_file_path=args['test_path'],
+            path_to_reaction_file=args['test_path'],
             candidate_bond_path=path_to_candidate_bonds['test'], mode='test',
             max_num_change_combos_per_reaction=args['max_num_change_combos_per_reaction_eval'],
             num_processes=args['num_processes'])

--- a/examples/reaction_prediction/rexgen_direct/candidate_ranking_train.py
+++ b/examples/reaction_prediction/rexgen_direct/candidate_ranking_train.py
@@ -24,7 +24,7 @@ def main(args, path_to_candidate_bonds):
             num_processes=args['num_processes'])
     else:
         train_set = WLNRankDataset(
-            raw_file_path=args['train_path'],
+            path_to_reaction_file=args['train_path'],
             candidate_bond_path=path_to_candidate_bonds['train'], mode='train',
             max_num_change_combos_per_reaction=args['max_num_change_combos_per_reaction_train'],
             num_processes=args['num_processes'])
@@ -36,7 +36,7 @@ def main(args, path_to_candidate_bonds):
             num_processes=args['num_processes'])
     else:
         val_set = WLNRankDataset(
-            raw_file_path=args['val_path'],
+            path_to_reaction_file=args['val_path'],
             candidate_bond_path=path_to_candidate_bonds['val'], mode='val',
             max_num_change_combos_per_reaction=args['max_num_change_combos_per_reaction_eval'],
             num_processes=args['num_processes'])

--- a/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
+++ b/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
@@ -27,7 +27,7 @@ def main(args):
                                     mol_graph_path=args['test_path'] + '.bin',
                                     num_processes=args['num_processes'],
                                     load=args['load'],
-                                    reaction_validity_result_path=args['result_path'])
+                                    reaction_validity_result_prefix='test')
     test_loader = DataLoader(test_set, batch_size=args['batch_size'],
                              collate_fn=collate_center, shuffle=False)
 

--- a/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
+++ b/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
@@ -27,7 +27,7 @@ def main(args):
                                     mol_graph_path=args['test_path'] + '.bin',
                                     num_processes=args['num_processes'],
                                     load=args['load'],
-                                    reaction_validity_result_path=args['center_results'])
+                                    reaction_validity_result_path=args['result_path'])
     test_loader = DataLoader(test_set, batch_size=args['batch_size'],
                              collate_fn=collate_center, shuffle=False)
 

--- a/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
+++ b/examples/reaction_prediction/rexgen_direct/find_reaction_center_eval.py
@@ -26,7 +26,8 @@ def main(args):
         test_set = WLNCenterDataset(raw_file_path=args['test_path'],
                                     mol_graph_path=args['test_path'] + '.bin',
                                     num_processes=args['num_processes'],
-                                    load=args['load'])
+                                    load=args['load'],
+                                    reaction_validity_result_path=args['center_results'])
     test_loader = DataLoader(test_set, batch_size=args['batch_size'],
                              collate_fn=collate_center, shuffle=False)
 

--- a/examples/reaction_prediction/rexgen_direct/find_reaction_center_train.py
+++ b/examples/reaction_prediction/rexgen_direct/find_reaction_center_train.py
@@ -23,13 +23,15 @@ def load_dataset(args):
     else:
         train_set = WLNCenterDataset(raw_file_path=args['train_path'],
                                      mol_graph_path='train.bin',
-                                     num_processes=args['num_processes'])
+                                     num_processes=args['num_processes'],
+                                     reaction_validity_result_prefix='train')
     if args['val_path'] is None:
         val_set = USPTOCenter('val', num_processes=args['num_processes'])
     else:
         val_set = WLNCenterDataset(raw_file_path=args['val_path'],
                                    mol_graph_path='val.bin',
-                                   num_processes=args['num_processes'])
+                                   num_processes=args['num_processes'],
+                                   reaction_validity_result_prefix='val')
 
     return train_set, val_set
 

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -81,7 +81,7 @@ def test_wln_reaction():
             candidate_string += '\n'
             f.write(candidate_string)
 
-    dataset = WLNRankDataset('test.txt', 'test_candidate_bond_changes.txt', 'train')
+    dataset = WLNRankDataset('test.txt.proc', 'test_candidate_bond_changes.txt', 'train')
     remove_file('test.txt')
     remove_file('test.txt.proc')
     remove_file('test_graphs.bin')
@@ -103,8 +103,8 @@ def test_wln_reaction():
     remove_file('test.txt')
     remove_file('test.txt.proc')
     remove_file('test_graphs.bin')
-    remove_file('valid_reactions.proc')
-    remove_file('invalid_reactions.proc')
+    remove_file('_valid_reactions.proc')
+    remove_file('_invalid_reactions.proc')
 
 if __name__ == '__main__':
     test_alchemy()

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -87,6 +87,25 @@ def test_wln_reaction():
     remove_file('test_graphs.bin')
     remove_file('test_candidate_bond_changes.txt')
 
+    # Test a file of both valid and invalid reactions
+    reaction1 = '[CH2:15]([CH:16]([CH3:17])[CH3:18])[Mg+:19].[CH2:20]1[O:21][CH2:22][CH2:23]' \
+                '[CH2:24]1.[Cl-:14].[OH:1][c:2]1[n:3][cH:4][c:5]([C:6](=[O:7])[N:8]([O:9]' \
+                '[CH3:10])[CH3:11])[cH:12][cH:13]1>>[OH:1][c:2]1[n:3][cH:4][c:5]([C:6](=[O:7])' \
+                '[CH2:15][CH:16]([CH3:17])[CH3:18])[cH:12][cH:13]1\n'
+    reaction2 = '[CH3:14][NH2:15].[N+:1](=[O:2])([O-:3])[c:4]1[cH:5][c:6]([C:7](=[O:8])[OH:9])' \
+                '[cH:10][cH:11][c:12]1[Cl:44].[OH2:16]>>[N+:1](=[O:2])([O-:3])[c:4]1[cH:5][c:6]' \
+                '([C:7](=[O:8])[OH:9])[cH:10][cH:11][c:12]1[NH:15][CH3:14]\n'
+    reactions = [reaction1, reaction2]
+    with open('test.txt', 'w') as f:
+        for reac in reactions:
+            f.write(reac)
+    dataset = WLNCenterDataset('test.txt', 'test_graphs.bin')
+    remove_file('test.txt')
+    remove_file('test.txt.proc')
+    remove_file('test_graphs.bin')
+    remove_file('valid_reactions.proc')
+    remove_file('invalid_reactions.proc')
+
 if __name__ == '__main__':
     test_alchemy()
     test_pdbbind()


### PR DESCRIPTION
As suggested in #18 by @autodataming , we don't want to terminate the prediction process if some reactions cannot be properly handled by the model. With this PR, we perform a first pass to check which reactions can be handled by the model first and record reactions that cannot be handled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
