### PR TITLE
Remove the Requirement for RDKit in Importing dgllife

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ DGL-LifeSci requires python 3.6+, DGL 0.4.3+ and PyTorch 1.2.0+.
 [Install dgl](https://www.dgl.ai/pages/start.html)
 
 
-Additionally, we require `RDKit 2018.09.3` for cheminformatics. We recommend installing it with
+Additionally, we require `RDKit 2018.09.3` for utils related to cheminformatics. We recommend installing it with
 
 ```
 conda install -c rdkit rdkit==2018.09.3

--- a/python/dgllife/__init__.py
+++ b/python/dgllife/__init__.py
@@ -5,7 +5,13 @@
 #
 # DGL-based package for applications in life science.
 
-from . import data
-from . import model
-from . import utils
 from .libinfo import __version__
+from . import model
+
+try:
+    import rdkit
+except:
+    print('RDKit is not installed, which is required for utils related to Cheminformatics.')
+
+from . import data
+from . import utils

--- a/python/dgllife/__init__.py
+++ b/python/dgllife/__init__.py
@@ -13,4 +13,4 @@ try:
     from . import data
     from . import utils
 except:
-    print('RDKit is not installed, which is required for utils related to Cheminformatics.')
+    pass

--- a/python/dgllife/__init__.py
+++ b/python/dgllife/__init__.py
@@ -12,5 +12,5 @@ try:
     import rdkit
     from . import data
     from . import utils
-except:
+except ImportError:
     print('RDKit is not installed, which is required for utils related to cheminformatics')

--- a/python/dgllife/__init__.py
+++ b/python/dgllife/__init__.py
@@ -10,8 +10,7 @@ from . import model
 
 try:
     import rdkit
+    from . import data
+    from . import utils
 except:
     print('RDKit is not installed, which is required for utils related to Cheminformatics.')
-
-from . import data
-from . import utils

--- a/python/dgllife/__init__.py
+++ b/python/dgllife/__init__.py
@@ -13,4 +13,4 @@ try:
     from . import data
     from . import utils
 except:
-    pass
+    print('RDKit is not installed, which is required for utils related to cheminformatics')

--- a/python/dgllife/model/model_zoo/__init__.py
+++ b/python/dgllife/model/model_zoo/__init__.py
@@ -22,7 +22,7 @@ try:
     # DGMG requires RDKit support
     from .dgmg import *
     from .jtnn import *
-except:
+except ImportError:
     pass
 
 # Reaction prediction

--- a/python/dgllife/model/model_zoo/__init__.py
+++ b/python/dgllife/model/model_zoo/__init__.py
@@ -21,9 +21,9 @@ from .gnn_ogb_predictor import *
 try:
     # DGMG requires RDKit support
     from .dgmg import *
+    from .jtnn import *
 except:
     pass
-from .jtnn import *
 
 # Reaction prediction
 from .wln_reaction_center import *

--- a/python/dgllife/model/model_zoo/__init__.py
+++ b/python/dgllife/model/model_zoo/__init__.py
@@ -18,7 +18,11 @@ from .weave_predictor import *
 from .gnn_ogb_predictor import *
 
 # Generative models
-from .dgmg import *
+try:
+    # DGMG requires RDKit support
+    from .dgmg import *
+except:
+    pass
 from .jtnn import *
 
 # Reaction prediction

--- a/python/dgllife/model/model_zoo/dgmg.py
+++ b/python/dgllife/model/model_zoo/dgmg.py
@@ -15,8 +15,12 @@ import torch.nn.init as init
 
 from dgl import DGLGraph
 from functools import partial
-from rdkit import Chem
 from torch.distributions import Categorical
+
+try:
+    from rdkit import Chem
+except:
+    print('RDKit is not installed, which is required for utils related to Cheminformatics.')
 
 __all__ = ['DGMG']
 

--- a/python/dgllife/model/model_zoo/dgmg.py
+++ b/python/dgllife/model/model_zoo/dgmg.py
@@ -15,12 +15,8 @@ import torch.nn.init as init
 
 from dgl import DGLGraph
 from functools import partial
+from rdkit import Chem
 from torch.distributions import Categorical
-
-try:
-    from rdkit import Chem
-except:
-    print('RDKit is not installed, which is required for utils related to Cheminformatics.')
 
 __all__ = ['DGMG']
 

--- a/python/dgllife/model/pretrain.py
+++ b/python/dgllife/model/pretrain.py
@@ -11,10 +11,14 @@ import torch
 import torch.nn.functional as F
 
 from dgl.data.utils import _get_dgl_url, download, get_download_dir, extract_archive
-from rdkit import Chem
 
 from ..model import GCNPredictor, GATPredictor, AttentiveFPPredictor, DGMG, DGLJTNNVAE, \
     WLNReactionCenter, WLNReactionRanking, WeavePredictor, GIN
+
+try:
+    from rdkit import Chem
+except:
+    pass
 
 __all__ = ['load_pretrained']
 

--- a/python/dgllife/model/pretrain.py
+++ b/python/dgllife/model/pretrain.py
@@ -19,7 +19,7 @@ try:
     # Things requiring RDKit
     from rdkit import Chem
     from ..model import DGMG, DGLJTNNVAE
-except:
+except ImportError:
     pass
 
 __all__ = ['load_pretrained']

--- a/python/dgllife/model/pretrain.py
+++ b/python/dgllife/model/pretrain.py
@@ -12,11 +12,13 @@ import torch.nn.functional as F
 
 from dgl.data.utils import _get_dgl_url, download, get_download_dir, extract_archive
 
-from ..model import GCNPredictor, GATPredictor, AttentiveFPPredictor, DGMG, DGLJTNNVAE, \
+from ..model import GCNPredictor, GATPredictor, AttentiveFPPredictor, \
     WLNReactionCenter, WLNReactionRanking, WeavePredictor, GIN
 
 try:
+    # Things requiring RDKit
     from rdkit import Chem
+    from ..model import DGMG, DGLJTNNVAE
 except:
     pass
 


### PR DESCRIPTION
If users only want to import some model architectures, they don't need to have RDKit installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
