### PR TITLE
respect sanitize molecule flag when removing hydrogens

### DIFF
--- a/python/dgllife/utils/io.py
+++ b/python/dgllife/utils/io.py
@@ -133,7 +133,7 @@ def load_molecule(molecule_file, sanitize=False, calc_charges=False,
                 warnings.warn('Unable to compute charges for the molecule.')
 
         if remove_hs:
-            mol = Chem.RemoveHs(mol)
+            mol = Chem.RemoveHs(mol, sanitize=sanitize)
     except:
         return None, None
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

`Chem.RemoveHs()` has an argument for whether to sanitize molecules, this is `True` by default.
However the user is allowed to specify `Sanitize=False`.
This PR uses the user-specified `sanitize` flag during molecule preprocessing. And passes it to `Chem.RemoveHs`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

p.s. Nice work guys 👍 