### PR TITLE
Update import from dgl to dgl.data.utils

### DIFF
--- a/python/dgllife/data/csv_dataset.py
+++ b/python/dgllife/data/csv_dataset.py
@@ -10,7 +10,7 @@ import numpy as np
 import os
 import torch
 
-from dgl import save_graphs, load_graphs
+from dgl.data.utils import save_graphs, load_graphs
 
 from ..utils.io import pmap
 


### PR DESCRIPTION
*Description of changes:*
Updated an outdated import from dgl to point to dgl.data.utils where the save_graphs and load_graphs packages now live according to https://docs.dgl.ai/en/0.4.x/api/python/data.html#utils

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
