### PR TITLE
In rexgen example: Enabled reactants and products without bonds.

### DIFF
--- a/examples/reaction_prediction/rexgen_direct/candidate_ranking_train.py
+++ b/examples/reaction_prediction/rexgen_direct/candidate_ranking_train.py
@@ -77,9 +77,15 @@ def main(args, path_to_candidate_bonds):
             batch_combo_scores = batch_combo_scores.to(args['device'])
             batch_labels = batch_labels.to(args['device'])
             reactant_node_feats = batch_reactant_graphs.ndata.pop('hv').to(args['device'])
-            reactant_edge_feats = batch_reactant_graphs.edata.pop('he').to(args['device'])
             product_node_feats = batch_product_graphs.ndata.pop('hv').to(args['device'])
-            product_edge_feats = batch_product_graphs.edata.pop('he').to(args['device'])
+            if batch_reactant_graphs.num_edges() > 0:
+                reactant_edge_feats = batch_reactant_graphs.edata.pop('he').to(args['device'])
+            else:
+                reactant_edge_feats = torch.zeros((0, 5), device=args["device"])
+            if batch_product_graphs.num_edges() > 0:
+                product_edge_feats = batch_product_graphs.edata.pop('he').to(args['device'])
+            else:
+                product_edge_feats = torch.zeros((0, 5), device=args["device"])
 
             pred = model(reactant_graph=batch_reactant_graphs,
                          reactant_node_feats=reactant_node_feats,

--- a/examples/reaction_prediction/rexgen_direct/utils.py
+++ b/examples/reaction_prediction/rexgen_direct/utils.py
@@ -301,7 +301,10 @@ def reaction_center_prediction(device, model, mol_graphs, complete_graphs):
     mol_graphs = mol_graphs.to(device)
     complete_graphs = complete_graphs.to(device)
     node_feats = mol_graphs.ndata.pop('hv').to(device)
-    edge_feats = mol_graphs.edata.pop('he').to(device)
+    if mol_graphs.num_edges() > 0:
+        edge_feats = mol_graphs.edata.pop('he').to(device)
+    else:
+        edge_feats = torch.zeros((0, model.gnn.project_edge_messages.in_feats), device=device)
     node_pair_feats = complete_graphs.edata.pop('feats').to(device)
 
     return model(mol_graphs, complete_graphs, node_feats, edge_feats, node_pair_feats)
@@ -359,6 +362,8 @@ def get_candidate_bonds(reaction, preds, num_nodes, max_k, easy, include_scores=
                 reaction_bonds[bond] = True
 
     candidate_bonds = []
+    if len(preds)<max_k:
+        max_k = len(preds)
     topk_values, topk_indices = torch.topk(preds, max_k)
     for j in range(max_k):
         preds_j = topk_indices[j].cpu().item()
@@ -1161,9 +1166,15 @@ def candidate_ranking_eval(args, model, data_loader):
         batch_product_graphs = batch_product_graphs.to(args['device'])
         batch_combo_scores = batch_combo_scores.to(args['device'])
         reactant_node_feats = batch_reactant_graphs.ndata.pop('hv').to(args['device'])
-        reactant_edge_feats = batch_reactant_graphs.edata.pop('he').to(args['device'])
         product_node_feats = batch_product_graphs.ndata.pop('hv').to(args['device'])
-        product_edge_feats = batch_product_graphs.edata.pop('he').to(args['device'])
+        if batch_reactant_graphs.num_edges() > 0:
+            reactant_edge_feats = batch_reactant_graphs.edata.pop('he').to(args['device'])
+        else:
+            reactant_edge_feats = torch.zeros((0, 5), device=args["device"])
+        if batch_product_graphs.num_edges() > 0:
+            product_edge_feats = batch_product_graphs.edata.pop('he').to(args['device'])
+        else:
+            product_edge_feats = torch.zeros((0, 5), device=args["device"])
 
         # Get candidate products with top-k ranking
         with torch.no_grad():

--- a/python/dgllife/data/uspto.py
+++ b/python/dgllife/data/uspto.py
@@ -1313,11 +1313,12 @@ def construct_graphs_rank(info, edge_featurizer):
             feats = torch.tensor(feats).float()
             combo_edge_feats.extend([feats, feats.clone()])
 
-        combo_edge_feats = torch.stack(combo_edge_feats, dim=0)
         combo_graph = dgl.graph(([], []))
         combo_graph.add_nodes(reactant_graph.num_nodes())
-        combo_graph.add_edges(combo_src_list, combo_dst_list)
-        combo_graph.edata['he'] = combo_edge_feats
+        if len(combo_edge_feats) > 0:
+            combo_edge_feats = torch.stack(combo_edge_feats, dim=0)
+            combo_graph.add_edges(combo_src_list, combo_dst_list)
+            combo_graph.edata['he'] = combo_edge_feats
         reaction_graphs.append(combo_graph)
 
     return reaction_graphs

--- a/python/dgllife/data/uspto.py
+++ b/python/dgllife/data/uspto.py
@@ -1319,6 +1319,8 @@ def construct_graphs_rank(info, edge_featurizer):
             combo_edge_feats = torch.stack(combo_edge_feats, dim=0)
             combo_graph.add_edges(combo_src_list, combo_dst_list)
             combo_graph.edata['he'] = combo_edge_feats
+        else:
+            combo_graph.edata['he'] = torch.zeros((0, 5))
         reaction_graphs.append(combo_graph)
 
     return reaction_graphs

--- a/tests/model/test_gnn.py
+++ b/tests/model/test_gnn.py
@@ -74,6 +74,12 @@ def test_graph9():
     return bg, torch.zeros(bg.num_nodes()).long(), \
            torch.randn(bg.num_edges(), 2).float()
 
+def test_graph10():
+    """Graph with node and edge features, but no edges."""
+    g = dgl.graph(([], []), num_nodes=3, idtype=torch.int32)
+    return g, torch.arange(g.num_nodes()).float().reshape(-1, 1), \
+           torch.arange(2 * g.num_edges()).float().reshape(-1, 2)
+
 def test_attentivefp():
     if torch.cuda.is_available():
         device = torch.device('cuda:0')
@@ -315,6 +321,8 @@ def test_wln():
 
     g, node_feats, edge_feats = test_graph3()
     g, node_feats, edge_feats = g.to(device), node_feats.to(device), edge_feats.to(device)
+    g_ne, node_feats_ne, edge_feats_ne = test_graph10()
+    g_ne, node_feats_ne, edge_feats_ne = g_ne.to(device), node_feats_ne.to(device), edge_feats_ne.to(device)
     bg, batch_node_feats, batch_edge_feats = test_graph4()
     bg, batch_node_feats, batch_edge_feats = bg.to(device), batch_node_feats.to(device), \
                                              batch_edge_feats.to(device)
@@ -324,6 +332,7 @@ def test_wln():
               edge_in_feats=2).to(device)
     gnn.reset_parameters()
     assert gnn(g, node_feats, edge_feats).shape == torch.Size([3, 300])
+    assert gnn(g_ne, node_feats_ne, edge_feats_ne).shape == torch.Size([3, 300])
     assert gnn(bg, batch_node_feats, batch_edge_feats).shape == torch.Size([8, 300])
 
     # Test configured setting
@@ -332,6 +341,7 @@ def test_wln():
               node_out_feats=3,
               n_layers=1).to(device)
     assert gnn(g, node_feats, edge_feats).shape == torch.Size([3, 3])
+    assert gnn(g_ne, node_feats_ne, edge_feats_ne).shape == torch.Size([3, 3])
     assert gnn(bg, batch_node_feats, batch_edge_feats).shape == torch.Size([8, 3])
 
 def test_graphsage():


### PR DESCRIPTION
In dgllife: Enable graphs without edges in WLN.

*Issue #134*

*Description of changes:*
In rexgen example: Enabled reactant and product graphs that have no edges. This required changes in core (USPTO set and WLN model).  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
