### PR TITLE
[Model] Set Bias to be True by default for GAT and GATPredictor

### DIFF
--- a/python/dgllife/model/model_zoo/gat_predictor.py
+++ b/python/dgllife/model/model_zoo/gat_predictor.py
@@ -65,6 +65,9 @@ class GATPredictor(nn.Module):
         results for the i-th GAT layer. ``len(activations)`` equals the number of GAT layers.
         By default, ELU is applied for intermediate GAT layers and no activation is applied
         for the last GAT layer.
+    biases : list of bool
+        ``biases[i]`` gives whether to add bias for the i-th GAT layer. ``len(activations)``
+        equals the number of GAT layers. By default, bias is added for all GAT layers.
     classifier_hidden_feats : int
         (Deprecated, see ``predictor_hidden_feats``) Size of hidden graph representations
         in the classifier. Default to 128.
@@ -80,7 +83,7 @@ class GATPredictor(nn.Module):
     """
     def __init__(self, in_feats, hidden_feats=None, num_heads=None, feat_drops=None,
                  attn_drops=None, alphas=None, residuals=None, agg_modes=None, activations=None,
-                 classifier_hidden_feats=128, classifier_dropout=0., n_tasks=1,
+                 biases=None, classifier_hidden_feats=128, classifier_dropout=0., n_tasks=1,
                  predictor_hidden_feats=128, predictor_dropout=0.):
         super(GATPredictor, self).__init__()
 
@@ -102,7 +105,8 @@ class GATPredictor(nn.Module):
                        alphas=alphas,
                        residuals=residuals,
                        agg_modes=agg_modes,
-                       activations=activations)
+                       activations=activations,
+                       biases=biases)
 
         if self.gnn.agg_modes[-1] == 'flatten':
             gnn_out_feats = self.gnn.hidden_feats[-1] * self.gnn.num_heads[-1]

--- a/python/dgllife/model/pretrain/moleculenet/bace.py
+++ b/python/dgllife/model/pretrain/moleculenet/bace.py
@@ -81,6 +81,7 @@ def create_bace_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.2547844032722401],
                             residuals=[False],
+                            biases=[False],
                             predictor_hidden_feats=128,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -95,6 +96,7 @@ def create_bace_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.6702823790658061] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=128,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/bbbp.py
+++ b/python/dgllife/model/pretrain/moleculenet/bbbp.py
@@ -83,6 +83,7 @@ def create_bbbp_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.6544012585238377] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=256,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -97,6 +98,7 @@ def create_bbbp_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.8731920595699334] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=256,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/clintox.py
+++ b/python/dgllife/model/pretrain/moleculenet/clintox.py
@@ -77,6 +77,7 @@ def create_clintox_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.4828530106865167],
                             residuals=[False],
+                            biases=[False],
                             predictor_hidden_feats=128,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -90,6 +91,7 @@ def create_clintox_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.3794180901463749],
                             residuals=[True],
+                            biases=[False],
                             predictor_hidden_feats=32,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/esol.py
+++ b/python/dgllife/model/pretrain/moleculenet/esol.py
@@ -79,6 +79,7 @@ def create_esol_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.4994779445224584],
                             residuals=[True],
+                            biases=[False],
                             predictor_hidden_feats=16,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -92,6 +93,7 @@ def create_esol_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.7197105722372982],
                             residuals=[False],
+                            biases=[False],
                             predictor_hidden_feats=32,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/freesolv.py
+++ b/python/dgllife/model/pretrain/moleculenet/freesolv.py
@@ -86,6 +86,7 @@ def create_freesolv_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.6211392042947481],
                             residuals=[True],
+                            biases=[False],
                             predictor_hidden_feats=256,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -100,6 +101,7 @@ def create_freesolv_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.6294479518124414] * num_gnn_layers,
                             residuals=[True] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=64,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/hiv.py
+++ b/python/dgllife/model/pretrain/moleculenet/hiv.py
@@ -81,6 +81,7 @@ def create_hiv_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.0821566804349384] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=64,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -95,6 +96,7 @@ def create_hiv_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.3649234413811788] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=64,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/lipophilicity.py
+++ b/python/dgllife/model/pretrain/moleculenet/lipophilicity.py
@@ -88,6 +88,7 @@ def create_lipophilicity_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.41300745504829595] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=64,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -101,6 +102,7 @@ def create_lipophilicity_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.7133648170252214],
                             residuals=[False],
+                            biases=[False],
                             predictor_hidden_feats=64,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/muv.py
+++ b/python/dgllife/model/pretrain/moleculenet/muv.py
@@ -77,6 +77,7 @@ def create_muv_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.8145285541930105] * num_gnn_layers,
                             residuals=[True] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=128,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -90,6 +91,7 @@ def create_muv_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.9101107032743763],
                             residuals=[False],
+                            biases=[False],
                             predictor_hidden_feats=32,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/pcba.py
+++ b/python/dgllife/model/pretrain/moleculenet/pcba.py
@@ -82,6 +82,7 @@ def create_pcba_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.0194367227727808] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=64,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -96,6 +97,7 @@ def create_pcba_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.25837424873685433] * num_gnn_layers,
                             residuals=[True] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=16,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/sider.py
+++ b/python/dgllife/model/pretrain/moleculenet/sider.py
@@ -87,6 +87,7 @@ def create_sider_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.7874749485670144] * num_gnn_layers,
                             residuals=[True] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=64,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -101,6 +102,7 @@ def create_sider_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.15881060281037407] * num_gnn_layers,
                             residuals=[True] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=128,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/tox21.py
+++ b/python/dgllife/model/pretrain/moleculenet/tox21.py
@@ -68,6 +68,7 @@ def create_tox21_model(model_name):
                             num_heads=[4, 4],
                             agg_modes=['flatten', 'mean'],
                             activations=[F.elu, None],
+                            biases=[False, False],
                             predictor_hidden_feats=64,
                             n_tasks=n_tasks)
 
@@ -114,6 +115,7 @@ def create_tox21_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.574285650239047],
                             residuals=[True],
+                            biases=[False],
                             predictor_hidden_feats=32,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -127,6 +129,7 @@ def create_tox21_model(model_name):
                             attn_drops=[dropout],
                             alphas=[0.3471639890634216],
                             residuals=[False],
+                            biases=[False],
                             predictor_hidden_feats=128,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)

--- a/python/dgllife/model/pretrain/moleculenet/toxcast.py
+++ b/python/dgllife/model/pretrain/moleculenet/toxcast.py
@@ -85,6 +85,7 @@ def create_toxcast_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.5850073967467644] * num_gnn_layers,
                             residuals=[True] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=256,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)
@@ -99,6 +100,7 @@ def create_toxcast_model(model_name):
                             attn_drops=[dropout] * num_gnn_layers,
                             alphas=[0.8044239663965763] * num_gnn_layers,
                             residuals=[False] * num_gnn_layers,
+                            biases=[False] * num_gnn_layers,
                             predictor_hidden_feats=128,
                             predictor_dropout=dropout,
                             n_tasks=n_tasks)


### PR DESCRIPTION
There's a bug in `GATConv` as of DGL 0.6.1 that the module tries to reset bias even when `bias=False`. While this has been fixed in the master branch of DGL, users can easily encounter the issue with DGL 0.6.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
