### PR TITLE
Fix device placement in ogbg_ppa graph property prediction example

### DIFF
--- a/examples/property_prediction/ogbg_ppa/main.py
+++ b/examples/property_prediction/ogbg_ppa/main.py
@@ -14,9 +14,9 @@ def train(model, device, loader, criterion, optimizer):
 
     for step, batch in enumerate(tqdm(loader, desc="Iteration")):
         bg, labels = batch
+        bg, labels = bg.to(device), labels.to(device)
         nfeats = bg.ndata['h']
         efeats = bg.edata['feat']
-        labels, nfeats, efeats = labels.to(device), nfeats.to(device), efeats.to(device)
         # only one node
         if bg.batch_size == 1:
             pass

--- a/examples/property_prediction/ogbg_ppa/main.py
+++ b/examples/property_prediction/ogbg_ppa/main.py
@@ -34,9 +34,9 @@ def eval(model, device, loader, evaluator):
 
     for step, batch in enumerate(tqdm(loader, desc="Iteration")):
         bg, labels = batch
+        bg, labels = bg.to(device), labels.to(device)
         nfeats = bg.ndata['h']
         efeats = bg.edata['feat']
-        labels, nfeats, efeats = labels.to(device), nfeats.to(device), efeats.to(device)
         # only one node
         if bg.batch_size == 1:
             pass


### PR DESCRIPTION
*Issue #, if available:*
The batch of graphs does not get placed to `device` and so fails when using GPU.

*Description of changes:*
Set the proper device placement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
