### PR TITLE
unpin scikit-learn version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=[package for package in find_packages()
               if package.startswith('dgllife')],
     install_requires=[
-        'scikit-learn>=0.22.2, <1.0',
+        'scikit-learn>=0.22.2',
         'pandas',
         'requests>=2.22.0',
         'tqdm',


### PR DESCRIPTION
It doesn’t matter for you that scikit-learn 1.x doesn’t support Python 3.6 anymore. Their metadata will automatically prevent installation on that Python version.

What does matter is that there’s no reason for you to prevent installation of scikit-learn>=1.0