### PR TITLE
Add top-level setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,1 @@
+from python.setup import *


### PR DESCRIPTION
It helps since some python build systems won't let devs do subdirectories, and the release schedule can be a little behind commits.

*Issue #, if available:*

*Description of changes:*
Add top-level setup.py that redirects to `python/setup.py`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
