### PR TITLE
Add allow_zero_in_degree option for gat and gcn models

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@ Contributors
 * [Vignesh Venkataraman](https://github.com/VIGNESHinZONE): PAGTN
 * [Eric O. Korman](https://github.com/ekorman): Fix for ogbg_ppa
 * [Marcos Leal](https://github.com/marcossilva): Change default number of processes to 1 for rexgen
+* [Andrew Stolman](https://github.com/astolman): Add allow_zero_in_degree option for GAT and GCN

--- a/python/dgllife/model/gnn/gat.py
+++ b/python/dgllife/model/gnn/gat.py
@@ -9,10 +9,9 @@
 
 import torch.nn as nn
 import torch.nn.functional as F
-
 from dgl.nn.pytorch import GATConv
 
-__all__ = ['GAT']
+__all__ = ["GAT"]
 
 # pylint: disable=W0221
 class GATLayer(nn.Module):
@@ -43,15 +42,38 @@ class GATLayer(nn.Module):
         Activation function applied to the aggregated multi-head results, default to None.
     bias : bool
         Whether to use bias in the GAT layer.
+    allow_zero_in_degree: bool
+        Whether to allow zero in degree nodes in graph. Defaults to False.
     """
-    def __init__(self, in_feats, out_feats, num_heads, feat_drop, attn_drop,
-                 alpha=0.2, residual=True, agg_mode='flatten', activation=None, bias=True):
+
+    def __init__(
+        self,
+        in_feats,
+        out_feats,
+        num_heads,
+        feat_drop,
+        attn_drop,
+        alpha=0.2,
+        residual=True,
+        agg_mode="flatten",
+        activation=None,
+        bias=True,
+        allow_zero_in_degree=False,
+    ):
         super(GATLayer, self).__init__()
 
-        self.gat_conv = GATConv(in_feats=in_feats, out_feats=out_feats, num_heads=num_heads,
-                                feat_drop=feat_drop, attn_drop=attn_drop,
-                                negative_slope=alpha, residual=residual, bias=bias)
-        assert agg_mode in ['flatten', 'mean']
+        self.gat_conv = GATConv(
+            in_feats=in_feats,
+            out_feats=out_feats,
+            num_heads=num_heads,
+            feat_drop=feat_drop,
+            attn_drop=attn_drop,
+            negative_slope=alpha,
+            residual=residual,
+            bias=bias,
+            allow_zero_in_degree=allow_zero_in_degree,
+        )
+        assert agg_mode in ["flatten", "mean"]
         self.agg_mode = agg_mode
         self.activation = activation
 
@@ -79,7 +101,7 @@ class GATLayer(nn.Module):
               out_feats * num_heads in initialization otherwise.
         """
         feats = self.gat_conv(bg, feats)
-        if self.agg_mode == 'flatten':
+        if self.agg_mode == "flatten":
             feats = feats.flatten(1)
         else:
             feats = feats.mean(1)
@@ -88,6 +110,7 @@ class GATLayer(nn.Module):
             feats = self.activation(feats)
 
         return feats
+
 
 class GAT(nn.Module):
     r"""GAT from `Graph Attention Networks <https://arxiv.org/abs/1710.10903>`__
@@ -132,10 +155,25 @@ class GAT(nn.Module):
     biases : list of bool
         ``biases[i]`` gives whether to use bias for the i-th GAT layer. ``len(activations)``
         equals the number of GAT layers. By default, we use bias for all GAT layers.
+    allow_zero_in_degree: bool
+        Whether to allow zero in degree nodes in graph for all layers. By default, will not
+        allow zero in degree nodes.
     """
-    def __init__(self, in_feats, hidden_feats=None, num_heads=None, feat_drops=None,
-                 attn_drops=None, alphas=None, residuals=None, agg_modes=None, activations=None,
-                 biases=None):
+
+    def __init__(
+        self,
+        in_feats,
+        hidden_feats=None,
+        num_heads=None,
+        feat_drops=None,
+        attn_drops=None,
+        alphas=None,
+        residuals=None,
+        agg_modes=None,
+        activations=None,
+        biases=None,
+        allow_zero_in_degree=False,
+    ):
         super(GAT, self).__init__()
 
         if hidden_feats is None:
@@ -145,37 +183,59 @@ class GAT(nn.Module):
         if num_heads is None:
             num_heads = [4 for _ in range(n_layers)]
         if feat_drops is None:
-            feat_drops = [0. for _ in range(n_layers)]
+            feat_drops = [0.0 for _ in range(n_layers)]
         if attn_drops is None:
-            attn_drops = [0. for _ in range(n_layers)]
+            attn_drops = [0.0 for _ in range(n_layers)]
         if alphas is None:
             alphas = [0.2 for _ in range(n_layers)]
         if residuals is None:
             residuals = [True for _ in range(n_layers)]
         if agg_modes is None:
-            agg_modes = ['flatten' for _ in range(n_layers - 1)]
-            agg_modes.append('mean')
+            agg_modes = ["flatten" for _ in range(n_layers - 1)]
+            agg_modes.append("mean")
         if activations is None:
             activations = [F.elu for _ in range(n_layers - 1)]
             activations.append(None)
         if biases is None:
             biases = [True for _ in range(n_layers)]
-        lengths = [len(hidden_feats), len(num_heads), len(feat_drops), len(attn_drops),
-                   len(alphas), len(residuals), len(agg_modes), len(activations), len(biases)]
-        assert len(set(lengths)) == 1, 'Expect the lengths of hidden_feats, num_heads, ' \
-                                       'feat_drops, attn_drops, alphas, residuals, ' \
-                                       'agg_modes, activations, and biases to be the same, ' \
-                                       'got {}'.format(lengths)
+        lengths = [
+            len(hidden_feats),
+            len(num_heads),
+            len(feat_drops),
+            len(attn_drops),
+            len(alphas),
+            len(residuals),
+            len(agg_modes),
+            len(activations),
+            len(biases),
+        ]
+        assert len(set(lengths)) == 1, (
+            "Expect the lengths of hidden_feats, num_heads, "
+            "feat_drops, attn_drops, alphas, residuals, "
+            "agg_modes, activations, and biases to be the same, "
+            "got {}".format(lengths)
+        )
         self.hidden_feats = hidden_feats
         self.num_heads = num_heads
         self.agg_modes = agg_modes
         self.gnn_layers = nn.ModuleList()
         for i in range(n_layers):
-            self.gnn_layers.append(GATLayer(in_feats, hidden_feats[i], num_heads[i],
-                                            feat_drops[i], attn_drops[i], alphas[i],
-                                            residuals[i], agg_modes[i], activations[i], 
-                                            biases[i]))
-            if agg_modes[i] == 'flatten':
+            self.gnn_layers.append(
+                GATLayer(
+                    in_feats,
+                    hidden_feats[i],
+                    num_heads[i],
+                    feat_drops[i],
+                    attn_drops[i],
+                    alphas[i],
+                    residuals[i],
+                    agg_modes[i],
+                    activations[i],
+                    biases[i],
+                    allow_zero_in_degree=allow_zero_in_degree,
+                )
+            )
+            if agg_modes[i] == "flatten":
                 in_feats = hidden_feats[i] * num_heads[i]
             else:
                 in_feats = hidden_feats[i]


### PR DESCRIPTION
This adds the `allow_zero_in_degree` option to be set in the model. This option exists in the base dgl layer objects. This change just adds the option to the GCN and GAT constructors to pass it down to the dgl layer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
