### PR TITLE
Cache mol featurizer at init time

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,3 +24,4 @@ Contributors
 * [Marcos Leal](https://github.com/marcossilva): Change default number of processes to 1 for rexgen
 * [Raymond Gasper](https://github.com/rgasper): GATv2
 * [Andrew Stolman](https://github.com/astolman): Add allow_zero_in_degree option for GAT and GCN
+* [In-Ho Yi](https://github.com/chajath): WeaveAtomFeaturizer performance fix

--- a/python/dgllife/utils/featurizers.py
+++ b/python/dgllife/utils/featurizers.py
@@ -1121,8 +1121,7 @@ class WeaveAtomFeaturizer(object):
         ])
 
         fdef_name = osp.join(RDConfig.RDDataDir, "BaseFeatures.fdef")
-        mol_featurizer = ChemicalFeatures.BuildFeatureFactory(fdef_name)
-        self._mol_featurizer = mol_featurizer
+        self._mol_featurizer = ChemicalFeatures.BuildFeatureFactory(fdef_name)
 
     def feat_size(self):
         """Get the feature size.

--- a/python/dgllife/utils/featurizers.py
+++ b/python/dgllife/utils/featurizers.py
@@ -1120,6 +1120,10 @@ class WeaveAtomFeaturizer(object):
             partial(atom_hybridization_one_hot, allowable_set=hybridization_types)
         ])
 
+        fdef_name = osp.join(RDConfig.RDDataDir, "BaseFeatures.fdef")
+        mol_featurizer = ChemicalFeatures.BuildFeatureFactory(fdef_name)
+        self._mol_featurizer = mol_featurizer
+
     def feat_size(self):
         """Get the feature size.
 
@@ -1186,9 +1190,7 @@ class WeaveAtomFeaturizer(object):
         num_atoms = mol.GetNumAtoms()
 
         # Get information for donor and acceptor
-        fdef_name = osp.join(RDConfig.RDDataDir, 'BaseFeatures.fdef')
-        mol_featurizer = ChemicalFeatures.BuildFeatureFactory(fdef_name)
-        mol_feats = mol_featurizer.GetFeaturesForMol(mol)
+        mol_feats = self._mol_featurizer.GetFeaturesForMol(mol)
         is_donor, is_acceptor = self.get_donor_acceptor_info(mol_feats)
 
         # Get a symmetrized smallest set of smallest rings


### PR DESCRIPTION
On a batch scale, featurizer loading turned out to be a significant bottleneck.

*Issue #, if available:*
https://github.com/awslabs/dgl-lifesci/issues/205

*Description of changes:*
Load and cache mol featurizer at init time so that it can be reused.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
