### PR TITLE
Remove np.long which is no longer supported in latest numpy

### DIFF
--- a/python/dgllife/utils/complex_to_graph.py
+++ b/python/dgllife/utils/complex_to_graph.py
@@ -190,7 +190,7 @@ def PN_graph_construction_and_featurization(ligand_mol,
         np.block([
             [d_one_hot, np.zeros((n_d, f_e))],
             [np.zeros((n_e, f_d)), np.array(complex_bigraph.edata['e'])]
-        ]).astype(np.long)
+        ]).astype(np.int64)
     )
     return complex_bigraph, complex_knn_graph
 


### PR DESCRIPTION
### Problem repro
```
cd examples/binding_affinity_prediction
python3 main.py  -m PotentialNet -d PDBBind_core_pocket_random
...
FutureWarning: In the future `np.long` will be defined as the corresponding NumPy scalar.
  ]).astype(np.long)
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
  File "venv/lib/python3.9/site-packages/dgllife/utils/complex_to_graph.py", line 193, in PN_graph_construction_and_featurization
    ]).astype(np.long)
  File "venv/lib/python3.9/site-packages/numpy/__init__.py", line 320, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'long'
```

```
$ pip show numpy
Name: numpy
Version: 1.24.2
```