### PR TITLE
Fix residual for gcn layer

### DIFF
--- a/python/dgllife/model/gnn/gcn.py
+++ b/python/dgllife/model/gnn/gcn.py
@@ -100,7 +100,9 @@ class GCNLayer(nn.Module):
         """
         new_feats = self.graph_conv(g, feats)
         if self.residual:
-            res_feats = self.activation(self.res_connection(feats))
+            res_feats = self.activation(
+                self.res_connection(feats[: new_feats.shape[0]])
+            )
             new_feats = new_feats + res_feats
         new_feats = self.dropout(new_feats)
 


### PR DESCRIPTION
This makes the residual option for GCN layers compatible with dgl blocks with different numbers of src and dst nodes. Without this change, if a bipartite block was used in the forward function with fewer dst nodes than src nodes, an error would be thrown on addition because of the mismatched shapes. This makes it so that activation is only applied on the same number of rows as the GNN layer's output.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
